### PR TITLE
sanitize code

### DIFF
--- a/ClrAnalyzer.Core/ClrAnalyzer.Core.csproj
+++ b/ClrAnalyzer.Core/ClrAnalyzer.Core.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net4.6.1</TargetFramework>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 

--- a/ClrAnalyzer.Core/Dumps/CompiledMethodInfo.cs
+++ b/ClrAnalyzer.Core/Dumps/CompiledMethodInfo.cs
@@ -83,7 +83,7 @@ namespace ClrAnalyzer.Core.Dumps
 
         public void Release() => hook.RemoveHook();
         public static unsafe void NativeDump(IntPtr corJitInfoPtr, CorInfo* methodInfo,
-            CorJitFlag flags, IntPtr nativeEntry, IntPtr nativeSizeOfCode) => CorJitCompiler.DumpMethodInfo(corJitInfoPtr, methodInfo, flags, nativeEntry, nativeSizeOfCode);
+            CorJitFlag flags, IntPtr nativeEntry, IntPtr nativeSizeOfCode) =>   CorJitCompiler.DumpMethodInfo(corJitInfoPtr, methodInfo, flags, nativeEntry, nativeSizeOfCode);
 
         internal static unsafe CorJitCompiler.CorJitResult CompileMethodDel(IntPtr thisPtr, [In] IntPtr corJitInfoPtr, [In] CorInfo* methodInfo,
             CorJitFlag flags, [Out] IntPtr nativeEntry, [Out] IntPtr nativeSizeOfCode)

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net4.6.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net4.6.1</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ClrAnalyzer.Core\ClrAnalyzer.Core.csproj" />
+    <ProjectReference Include="..\Win32Native\Win32Native.vcxproj" />
   </ItemGroup>
 
 </Project>

--- a/Win32Native/corjit.h
+++ b/Win32Native/corjit.h
@@ -1,6 +1,7 @@
 #include "clrtypes.h"
 #include "corinfo.h"
 #include "jitee.h"
+#include "corjitflags.h"
 #include <iostream>
 #include <iomanip>
 #include <string>
@@ -217,30 +218,15 @@ public:
 
 #define CompileFunctionSig CorJitResult(*compileMethod)(void*, struct CORINFO_METHOD_INFO*, unsigned flags, BYTE**, ULONG*)
 
-extern "C" __declspec(dllexport) void __stdcall DumpMethodInfo(ICorJitInfo*, struct CORINFO_METHOD_INFO*, unsigned, BYTE**, ULONG*);
-
-void DumpMethodInfo(ICorJitInfo* comp, struct CORINFO_METHOD_INFO* info, unsigned flags, BYTE** nativeEntry, ULONG* nativeSizeOfCode)
+extern "C" __declspec(dllexport) void __stdcall DumpMethodInfo(ICorJitInfo* comp, struct CORINFO_METHOD_INFO* info, unsigned flags, BYTE** nativeEntry, ULONG* nativeSizeOfCode)
 {
-	if (flags != CORJIT_FLAGS::CORJIT_FLAG_CALL_GETJITFLAGS) return;
-	CORJIT_FLAGS corJitFlags;
-	try
-	{
-		//TODO: FIXME
-		//comp->getJitFlags(&corJitFlags, sizeof(corJitFlags));
-	}
-	catch (const std::exception& ex)
-	{
-		std::cout << ex.what() << std::endl;
-	}
-
-    std::cout << "jit flags: " << std::hex << corJitFlags.GetFlagsRaw() << std::endl;
     std::cout << "native size of code: " << info->ILCodeSize << std::endl;
-	auto buff = new char[info->ILCodeSize];
-	std::memcpy(buff, info->ILCode, info->ILCodeSize);
+    auto buff = new char[info->ILCodeSize];
+    std::memcpy(buff, info->ILCode, info->ILCodeSize);
     auto code = new std::string(buff);
     std::cout << "IL code: " << code << std::endl;
     delete code;
-	delete[] buff;
+    delete[] buff;
     auto f = comp->getMethodAttribs(info->ftn);
     std::cout << "method attribs: " << std::hex << f << std::endl;
 }

--- a/Win32Native/jitee.h
+++ b/Win32Native/jitee.h
@@ -12,306 +12,306 @@
 class JitFlags
 {
 public:
-	// clang-format off
-	enum JitFlag
-	{
-		JIT_FLAG_SPEED_OPT = 0,
-		JIT_FLAG_SIZE_OPT = 1,
-		JIT_FLAG_DEBUG_CODE = 2, // generate "debuggable" code (no code-mangling optimizations)
-		JIT_FLAG_DEBUG_EnC = 3, // We are in Edit-n-Continue mode
-		JIT_FLAG_DEBUG_INFO = 4, // generate line and local-var info
-		JIT_FLAG_MIN_OPT = 5, // disable all jit optimizations (not necesarily debuggable code)
-		JIT_FLAG_GCPOLL_CALLS = 6, // Emit calls to JIT_POLLGC for thread suspension.
-		JIT_FLAG_MCJIT_BACKGROUND = 7, // Calling from multicore JIT background thread, do not call JitComplete
+    // clang-format off
+    enum JitFlag
+    {
+        JIT_FLAG_SPEED_OPT = 0,
+        JIT_FLAG_SIZE_OPT = 1,
+        JIT_FLAG_DEBUG_CODE = 2, // generate "debuggable" code (no code-mangling optimizations)
+        JIT_FLAG_DEBUG_EnC = 3, // We are in Edit-n-Continue mode
+        JIT_FLAG_DEBUG_INFO = 4, // generate line and local-var info
+        JIT_FLAG_MIN_OPT = 5, // disable all jit optimizations (not necesarily debuggable code)
+        JIT_FLAG_GCPOLL_CALLS = 6, // Emit calls to JIT_POLLGC for thread suspension.
+        JIT_FLAG_MCJIT_BACKGROUND = 7, // Calling from multicore JIT background thread, do not call JitComplete
 
 #if defined(_TARGET_X86_)
 
-		JIT_FLAG_PINVOKE_RESTORE_ESP = 8, // Restore ESP after returning from inlined PInvoke
-		JIT_FLAG_TARGET_P4 = 9,
-		JIT_FLAG_USE_FCOMI = 10, // Generated code may use fcomi(p) instruction
-		JIT_FLAG_USE_CMOV = 11, // Generated code may use cmov instruction
-		JIT_FLAG_USE_SSE2 = 12, // Generated code may use SSE-2 instructions
+        JIT_FLAG_PINVOKE_RESTORE_ESP = 8, // Restore ESP after returning from inlined PInvoke
+        JIT_FLAG_TARGET_P4 = 9,
+        JIT_FLAG_USE_FCOMI = 10, // Generated code may use fcomi(p) instruction
+        JIT_FLAG_USE_CMOV = 11, // Generated code may use cmov instruction
+        JIT_FLAG_USE_SSE2 = 12, // Generated code may use SSE-2 instructions
 
 #else // !defined(_TARGET_X86_)
 
-		JIT_FLAG_UNUSED1 = 8,
-		JIT_FLAG_UNUSED2 = 9,
-		JIT_FLAG_UNUSED3 = 10,
-		JIT_FLAG_UNUSED4 = 11,
-		JIT_FLAG_UNUSED5 = 12,
+        JIT_FLAG_UNUSED1 = 8,
+        JIT_FLAG_UNUSED2 = 9,
+        JIT_FLAG_UNUSED3 = 10,
+        JIT_FLAG_UNUSED4 = 11,
+        JIT_FLAG_UNUSED5 = 12,
 
 #endif // !defined(_TARGET_X86_)
 
-		JIT_FLAG_UNUSED6 = 13,
+        JIT_FLAG_UNUSED6 = 13,
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-		JIT_FLAG_USE_AVX = 14,
-		JIT_FLAG_USE_AVX2 = 15,
-		JIT_FLAG_USE_AVX_512 = 16,
+        JIT_FLAG_USE_AVX = 14,
+        JIT_FLAG_USE_AVX2 = 15,
+        JIT_FLAG_USE_AVX_512 = 16,
 
 #else // !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
 
-		JIT_FLAG_UNUSED7 = 14,
-		JIT_FLAG_UNUSED8 = 15,
-		JIT_FLAG_UNUSED9 = 16,
+        JIT_FLAG_UNUSED7 = 14,
+        JIT_FLAG_UNUSED8 = 15,
+        JIT_FLAG_UNUSED9 = 16,
 
 #endif // !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_)
-		JIT_FLAG_FEATURE_SIMD = 17,
+        JIT_FLAG_FEATURE_SIMD = 17,
 #else
-		JIT_FLAG_UNUSED10 = 17,
+        JIT_FLAG_UNUSED10 = 17,
 #endif // !(defined(_TARGET_X86_) || defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_))
 
-		JIT_FLAG_MAKEFINALCODE = 18, // Use the final code generator, i.e., not the interpreter.
-		JIT_FLAG_READYTORUN = 19, // Use version-resilient code generation
-		JIT_FLAG_PROF_ENTERLEAVE = 20, // Instrument prologues/epilogues
-		JIT_FLAG_PROF_REJIT_NOPS = 21, // Insert NOPs to ensure code is re-jitable
-		JIT_FLAG_PROF_NO_PINVOKE_INLINE = 22, // Disables PInvoke inlining
-		JIT_FLAG_SKIP_VERIFICATION = 23, // (lazy) skip verification - determined without doing a full resolve. See comment below
-		JIT_FLAG_PREJIT = 24, // jit or prejit is the execution engine.
-		JIT_FLAG_RELOC = 25, // Generate relocatable code
-		JIT_FLAG_IMPORT_ONLY = 26, // Only import the function
-		JIT_FLAG_IL_STUB = 27, // method is an IL stub
-		JIT_FLAG_PROCSPLIT = 28, // JIT should separate code into hot and cold sections
-		JIT_FLAG_BBINSTR = 29, // Collect basic block profile information
-		JIT_FLAG_BBOPT = 30, // Optimize method based on profile information
-		JIT_FLAG_FRAMED = 31, // All methods have an EBP frame
-		JIT_FLAG_ALIGN_LOOPS = 32, // add NOPs before loops to align them at 16 byte boundaries
-		JIT_FLAG_PUBLISH_SECRET_PARAM = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
-		JIT_FLAG_GCPOLL_INLINE = 34, // JIT must inline calls to GCPoll when possible
-		JIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background
-		JIT_FLAG_USE_PINVOKE_HELPERS = 36, // The JIT should use the PINVOKE_{BEGIN,END} helpers instead of emitting inline transitions
-		JIT_FLAG_REVERSE_PINVOKE = 37, // The JIT should insert REVERSE_PINVOKE_{ENTER,EXIT} helpers into method prolog/epilog
-		JIT_FLAG_DESKTOP_QUIRKS = 38, // The JIT should generate desktop-quirk-compatible code
-		JIT_FLAG_TIER0 = 39, // This is the initial tier for tiered compilation which should generate code as quickly as possible
-		JIT_FLAG_TIER1 = 40, // This is the final tier (for now) for tiered compilation which should generate high quality code
+        JIT_FLAG_MAKEFINALCODE = 18, // Use the final code generator, i.e., not the interpreter.
+        JIT_FLAG_READYTORUN = 19, // Use version-resilient code generation
+        JIT_FLAG_PROF_ENTERLEAVE = 20, // Instrument prologues/epilogues
+        JIT_FLAG_PROF_REJIT_NOPS = 21, // Insert NOPs to ensure code is re-jitable
+        JIT_FLAG_PROF_NO_PINVOKE_INLINE = 22, // Disables PInvoke inlining
+        JIT_FLAG_SKIP_VERIFICATION = 23, // (lazy) skip verification - determined without doing a full resolve. See comment below
+        JIT_FLAG_PREJIT = 24, // jit or prejit is the execution engine.
+        JIT_FLAG_RELOC = 25, // Generate relocatable code
+        JIT_FLAG_IMPORT_ONLY = 26, // Only import the function
+        JIT_FLAG_IL_STUB = 27, // method is an IL stub
+        JIT_FLAG_PROCSPLIT = 28, // JIT should separate code into hot and cold sections
+        JIT_FLAG_BBINSTR = 29, // Collect basic block profile information
+        JIT_FLAG_BBOPT = 30, // Optimize method based on profile information
+        JIT_FLAG_FRAMED = 31, // All methods have an EBP frame
+        JIT_FLAG_ALIGN_LOOPS = 32, // add NOPs before loops to align them at 16 byte boundaries
+        JIT_FLAG_PUBLISH_SECRET_PARAM = 33, // JIT must place stub secret param into local 0.  (used by IL stubs)
+        JIT_FLAG_GCPOLL_INLINE = 34, // JIT must inline calls to GCPoll when possible
+        JIT_FLAG_SAMPLING_JIT_BACKGROUND = 35, // JIT is being invoked as a result of stack sampling for hot methods in the background
+        JIT_FLAG_USE_PINVOKE_HELPERS = 36, // The JIT should use the PINVOKE_{BEGIN,END} helpers instead of emitting inline transitions
+        JIT_FLAG_REVERSE_PINVOKE = 37, // The JIT should insert REVERSE_PINVOKE_{ENTER,EXIT} helpers into method prolog/epilog
+        JIT_FLAG_DESKTOP_QUIRKS = 38, // The JIT should generate desktop-quirk-compatible code
+        JIT_FLAG_TIER0 = 39, // This is the initial tier for tiered compilation which should generate code as quickly as possible
+        JIT_FLAG_TIER1 = 40, // This is the final tier (for now) for tiered compilation which should generate high quality code
 
 #if defined(_TARGET_ARM_)
-		JIT_FLAG_RELATIVE_CODE_RELOCS = 41, // JIT should generate PC-relative address computations instead of EE relocation records
+        JIT_FLAG_RELATIVE_CODE_RELOCS = 41, // JIT should generate PC-relative address computations instead of EE relocation records
 #else // !defined(_TARGET_ARM_)
-		JIT_FLAG_UNUSED11 = 41,
+        JIT_FLAG_UNUSED11 = 41,
 #endif // !defined(_TARGET_ARM_)
 
-		JIT_FLAG_NO_INLINING = 42, // JIT should not inline any called method into this method
+        JIT_FLAG_NO_INLINING = 42, // JIT should not inline any called method into this method
 
 #if defined(_TARGET_ARM64_)
 
-		JIT_FLAG_HAS_ARM64_AES = 43, // ID_AA64ISAR0_EL1.AES is 1 or better
-		JIT_FLAG_HAS_ARM64_ATOMICS = 44, // ID_AA64ISAR0_EL1.Atomic is 2 or better
-		JIT_FLAG_HAS_ARM64_CRC32 = 45, // ID_AA64ISAR0_EL1.CRC32 is 1 or better
-		JIT_FLAG_HAS_ARM64_DCPOP = 46, // ID_AA64ISAR1_EL1.DPB is 1 or better
-		JIT_FLAG_HAS_ARM64_DP = 47, // ID_AA64ISAR0_EL1.DP is 1 or better
-		JIT_FLAG_HAS_ARM64_FCMA = 48, // ID_AA64ISAR1_EL1.FCMA is 1 or better
-		JIT_FLAG_HAS_ARM64_FP = 49, // ID_AA64PFR0_EL1.FP is 0 or better
-		JIT_FLAG_HAS_ARM64_FP16 = 50, // ID_AA64PFR0_EL1.FP is 1 or better
-		JIT_FLAG_HAS_ARM64_JSCVT = 51, // ID_AA64ISAR1_EL1.JSCVT is 1 or better
-		JIT_FLAG_HAS_ARM64_LRCPC = 52, // ID_AA64ISAR1_EL1.LRCPC is 1 or better
-		JIT_FLAG_HAS_ARM64_PMULL = 53, // ID_AA64ISAR0_EL1.AES is 2 or better
-		JIT_FLAG_HAS_ARM64_SHA1 = 54, // ID_AA64ISAR0_EL1.SHA1 is 1 or better
-		JIT_FLAG_HAS_ARM64_SHA256 = 55, // ID_AA64ISAR0_EL1.SHA2 is 1 or better
-		JIT_FLAG_HAS_ARM64_SHA512 = 56, // ID_AA64ISAR0_EL1.SHA2 is 2 or better
-		JIT_FLAG_HAS_ARM64_SHA3 = 57, // ID_AA64ISAR0_EL1.SHA3 is 1 or better
-		JIT_FLAG_HAS_ARM64_SIMD = 58, // ID_AA64PFR0_EL1.AdvSIMD is 0 or better
-		JIT_FLAG_HAS_ARM64_SIMD_V81 = 59, // ID_AA64ISAR0_EL1.RDM is 1 or better
-		JIT_FLAG_HAS_ARM64_SIMD_FP16 = 60, // ID_AA64PFR0_EL1.AdvSIMD is 1 or better
-		JIT_FLAG_HAS_ARM64_SM3 = 61, // ID_AA64ISAR0_EL1.SM3 is 1 or better
-		JIT_FLAG_HAS_ARM64_SM4 = 62, // ID_AA64ISAR0_EL1.SM4 is 1 or better
-		JIT_FLAG_HAS_ARM64_SVE = 63  // ID_AA64PFR0_EL1.SVE is 1 or better
+        JIT_FLAG_HAS_ARM64_AES = 43, // ID_AA64ISAR0_EL1.AES is 1 or better
+        JIT_FLAG_HAS_ARM64_ATOMICS = 44, // ID_AA64ISAR0_EL1.Atomic is 2 or better
+        JIT_FLAG_HAS_ARM64_CRC32 = 45, // ID_AA64ISAR0_EL1.CRC32 is 1 or better
+        JIT_FLAG_HAS_ARM64_DCPOP = 46, // ID_AA64ISAR1_EL1.DPB is 1 or better
+        JIT_FLAG_HAS_ARM64_DP = 47, // ID_AA64ISAR0_EL1.DP is 1 or better
+        JIT_FLAG_HAS_ARM64_FCMA = 48, // ID_AA64ISAR1_EL1.FCMA is 1 or better
+        JIT_FLAG_HAS_ARM64_FP = 49, // ID_AA64PFR0_EL1.FP is 0 or better
+        JIT_FLAG_HAS_ARM64_FP16 = 50, // ID_AA64PFR0_EL1.FP is 1 or better
+        JIT_FLAG_HAS_ARM64_JSCVT = 51, // ID_AA64ISAR1_EL1.JSCVT is 1 or better
+        JIT_FLAG_HAS_ARM64_LRCPC = 52, // ID_AA64ISAR1_EL1.LRCPC is 1 or better
+        JIT_FLAG_HAS_ARM64_PMULL = 53, // ID_AA64ISAR0_EL1.AES is 2 or better
+        JIT_FLAG_HAS_ARM64_SHA1 = 54, // ID_AA64ISAR0_EL1.SHA1 is 1 or better
+        JIT_FLAG_HAS_ARM64_SHA256 = 55, // ID_AA64ISAR0_EL1.SHA2 is 1 or better
+        JIT_FLAG_HAS_ARM64_SHA512 = 56, // ID_AA64ISAR0_EL1.SHA2 is 2 or better
+        JIT_FLAG_HAS_ARM64_SHA3 = 57, // ID_AA64ISAR0_EL1.SHA3 is 1 or better
+        JIT_FLAG_HAS_ARM64_SIMD = 58, // ID_AA64PFR0_EL1.AdvSIMD is 0 or better
+        JIT_FLAG_HAS_ARM64_SIMD_V81 = 59, // ID_AA64ISAR0_EL1.RDM is 1 or better
+        JIT_FLAG_HAS_ARM64_SIMD_FP16 = 60, // ID_AA64PFR0_EL1.AdvSIMD is 1 or better
+        JIT_FLAG_HAS_ARM64_SM3 = 61, // ID_AA64ISAR0_EL1.SM3 is 1 or better
+        JIT_FLAG_HAS_ARM64_SM4 = 62, // ID_AA64ISAR0_EL1.SM4 is 1 or better
+        JIT_FLAG_HAS_ARM64_SVE = 63  // ID_AA64PFR0_EL1.SVE is 1 or better
 
 #elif defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-		JIT_FLAG_USE_SSE3 = 43,
-		JIT_FLAG_USE_SSSE3 = 44,
-		JIT_FLAG_USE_SSE41 = 45,
-		JIT_FLAG_USE_SSE42 = 46,
-		JIT_FLAG_USE_AES = 47,
-		JIT_FLAG_USE_BMI1 = 48,
-		JIT_FLAG_USE_BMI2 = 49,
-		JIT_FLAG_USE_FMA = 50,
-		JIT_FLAG_USE_LZCNT = 51,
-		JIT_FLAG_USE_PCLMULQDQ = 52,
-		JIT_FLAG_USE_POPCNT = 53,
-		JIT_FLAG_UNUSED23 = 54,
-		JIT_FLAG_UNUSED24 = 55,
-		JIT_FLAG_UNUSED25 = 56,
-		JIT_FLAG_UNUSED26 = 57,
-		JIT_FLAG_UNUSED27 = 58,
-		JIT_FLAG_UNUSED28 = 59,
-		JIT_FLAG_UNUSED29 = 60,
-		JIT_FLAG_UNUSED30 = 61,
-		JIT_FLAG_UNUSED31 = 62,
-		JIT_FLAG_UNUSED32 = 63
+        JIT_FLAG_USE_SSE3 = 43,
+        JIT_FLAG_USE_SSSE3 = 44,
+        JIT_FLAG_USE_SSE41 = 45,
+        JIT_FLAG_USE_SSE42 = 46,
+        JIT_FLAG_USE_AES = 47,
+        JIT_FLAG_USE_BMI1 = 48,
+        JIT_FLAG_USE_BMI2 = 49,
+        JIT_FLAG_USE_FMA = 50,
+        JIT_FLAG_USE_LZCNT = 51,
+        JIT_FLAG_USE_PCLMULQDQ = 52,
+        JIT_FLAG_USE_POPCNT = 53,
+        JIT_FLAG_UNUSED23 = 54,
+        JIT_FLAG_UNUSED24 = 55,
+        JIT_FLAG_UNUSED25 = 56,
+        JIT_FLAG_UNUSED26 = 57,
+        JIT_FLAG_UNUSED27 = 58,
+        JIT_FLAG_UNUSED28 = 59,
+        JIT_FLAG_UNUSED29 = 60,
+        JIT_FLAG_UNUSED30 = 61,
+        JIT_FLAG_UNUSED31 = 62,
+        JIT_FLAG_UNUSED32 = 63
 
 
 #else // !defined(_TARGET_ARM64_) && !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
 
-		JIT_FLAG_UNUSED12 = 43,
-		JIT_FLAG_UNUSED13 = 44,
-		JIT_FLAG_UNUSED14 = 45,
-		JIT_FLAG_UNUSED15 = 46,
-		JIT_FLAG_UNUSED16 = 47,
-		JIT_FLAG_UNUSED17 = 48,
-		JIT_FLAG_UNUSED18 = 49,
-		JIT_FLAG_UNUSED19 = 50,
-		JIT_FLAG_UNUSED20 = 51,
-		JIT_FLAG_UNUSED21 = 52,
-		JIT_FLAG_UNUSED22 = 53,
-		JIT_FLAG_UNUSED23 = 54,
-		JIT_FLAG_UNUSED24 = 55,
-		JIT_FLAG_UNUSED25 = 56,
-		JIT_FLAG_UNUSED26 = 57,
-		JIT_FLAG_UNUSED27 = 58,
-		JIT_FLAG_UNUSED28 = 59,
-		JIT_FLAG_UNUSED29 = 60,
-		JIT_FLAG_UNUSED30 = 61,
-		JIT_FLAG_UNUSED31 = 62,
-		JIT_FLAG_UNUSED32 = 63
+        JIT_FLAG_UNUSED12 = 43,
+        JIT_FLAG_UNUSED13 = 44,
+        JIT_FLAG_UNUSED14 = 45,
+        JIT_FLAG_UNUSED15 = 46,
+        JIT_FLAG_UNUSED16 = 47,
+        JIT_FLAG_UNUSED17 = 48,
+        JIT_FLAG_UNUSED18 = 49,
+        JIT_FLAG_UNUSED19 = 50,
+        JIT_FLAG_UNUSED20 = 51,
+        JIT_FLAG_UNUSED21 = 52,
+        JIT_FLAG_UNUSED22 = 53,
+        JIT_FLAG_UNUSED23 = 54,
+        JIT_FLAG_UNUSED24 = 55,
+        JIT_FLAG_UNUSED25 = 56,
+        JIT_FLAG_UNUSED26 = 57,
+        JIT_FLAG_UNUSED27 = 58,
+        JIT_FLAG_UNUSED28 = 59,
+        JIT_FLAG_UNUSED29 = 60,
+        JIT_FLAG_UNUSED30 = 61,
+        JIT_FLAG_UNUSED31 = 62,
+        JIT_FLAG_UNUSED32 = 63
 
 #endif // !defined(_TARGET_ARM64_) && !defined(_TARGET_X86_) && !defined(_TARGET_AMD64_)
 
-	};
-	// clang-format on
+    };
+    // clang-format on
 
-	JitFlags() : m_jitFlags(0)
-	{
-		// empty
-	}
+    JitFlags() : m_jitFlags(0)
+    {
+        // empty
+    }
 
-	// Convenience constructor to set exactly one flags.
-	JitFlags(JitFlag flag) : m_jitFlags(0)
-	{
-		Set(flag);
-	}
+    // Convenience constructor to set exactly one flags.
+    JitFlags(JitFlag flag) : m_jitFlags(0)
+    {
+        Set(flag);
+    }
 
-	void Reset()
-	{
-		m_jitFlags = 0;
-	}
+    void Reset()
+    {
+        m_jitFlags = 0;
+    }
 
-	void Set(JitFlag flag)
-	{
-		m_jitFlags |= 1ULL << (unsigned __int64)flag;
-	}
+    void Set(JitFlag flag)
+    {
+        m_jitFlags |= 1ULL << (unsigned __int64)flag;
+    }
 
-	void Clear(JitFlag flag)
-	{
-		m_jitFlags &= ~(1ULL << (unsigned __int64)flag);
-	}
+    void Clear(JitFlag flag)
+    {
+        m_jitFlags &= ~(1ULL << (unsigned __int64)flag);
+    }
 
-	bool IsSet(JitFlag flag) const
-	{
-		return (m_jitFlags & (1ULL << (unsigned __int64)flag)) != 0;
-	}
+    bool IsSet(JitFlag flag) const
+    {
+        return (m_jitFlags & (1ULL << (unsigned __int64)flag)) != 0;
+    }
 
-	void Add(const JitFlags& other)
-	{
-		m_jitFlags |= other.m_jitFlags;
-	}
+    void Add(const JitFlags& other)
+    {
+        m_jitFlags |= other.m_jitFlags;
+    }
 
-	void Remove(const JitFlags& other)
-	{
-		m_jitFlags &= ~other.m_jitFlags;
-	}
+    void Remove(const JitFlags& other)
+    {
+        m_jitFlags &= ~other.m_jitFlags;
+    }
 
-	bool IsEmpty() const
-	{
-		return m_jitFlags == 0;
-	}
+    bool IsEmpty() const
+    {
+        return m_jitFlags == 0;
+    }
 
-	void SetFromFlags(CORJIT_FLAGS flags)
-	{
-		// We don't want to have to check every one, so we assume it is exactly the same values as the JitFlag
-		// values defined in this type.
-		m_jitFlags = flags.GetFlagsRaw();
+    void SetFromFlags(CORJIT_FLAGS flags)
+    {
+        // We don't want to have to check every one, so we assume it is exactly the same values as the JitFlag
+        // values defined in this type.
+        m_jitFlags = flags.GetFlagsRaw();
 
-		if (sizeof(m_jitFlags) != sizeof(CORJIT_FLAGS)) return;
+        if (sizeof(m_jitFlags) != sizeof(CORJIT_FLAGS)) return;
 
 #define FLAGS_EQUAL(a, b) C_ASSERT((unsigned)(a) == (unsigned)(b))
 
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SPEED_OPT, JIT_FLAG_SPEED_OPT);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SIZE_OPT, JIT_FLAG_SIZE_OPT);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE, JIT_FLAG_DEBUG_CODE);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_EnC, JIT_FLAG_DEBUG_EnC);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_INFO, JIT_FLAG_DEBUG_INFO);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MIN_OPT, JIT_FLAG_MIN_OPT);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_GCPOLL_CALLS, JIT_FLAG_GCPOLL_CALLS);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MCJIT_BACKGROUND, JIT_FLAG_MCJIT_BACKGROUND);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SPEED_OPT, JIT_FLAG_SPEED_OPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SIZE_OPT, JIT_FLAG_SIZE_OPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE, JIT_FLAG_DEBUG_CODE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_EnC, JIT_FLAG_DEBUG_EnC);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_INFO, JIT_FLAG_DEBUG_INFO);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MIN_OPT, JIT_FLAG_MIN_OPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_GCPOLL_CALLS, JIT_FLAG_GCPOLL_CALLS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MCJIT_BACKGROUND, JIT_FLAG_MCJIT_BACKGROUND);
 
 #if defined(_TARGET_X86_)
 
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PINVOKE_RESTORE_ESP, JIT_FLAG_PINVOKE_RESTORE_ESP);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_TARGET_P4, JIT_FLAG_TARGET_P4);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_FCOMI, JIT_FLAG_USE_FCOMI);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_CMOV, JIT_FLAG_USE_CMOV);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE2, JIT_FLAG_USE_SSE2);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PINVOKE_RESTORE_ESP, JIT_FLAG_PINVOKE_RESTORE_ESP);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_TARGET_P4, JIT_FLAG_TARGET_P4);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_FCOMI, JIT_FLAG_USE_FCOMI);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_CMOV, JIT_FLAG_USE_CMOV);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE2, JIT_FLAG_USE_SSE2);
 
 #endif
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
 
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX, JIT_FLAG_USE_AVX);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX2, JIT_FLAG_USE_AVX2);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX_512, JIT_FLAG_USE_AVX_512);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX, JIT_FLAG_USE_AVX);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX2, JIT_FLAG_USE_AVX2);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AVX_512, JIT_FLAG_USE_AVX_512);
 
 #endif
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_)
 
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FEATURE_SIMD, JIT_FLAG_FEATURE_SIMD);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FEATURE_SIMD, JIT_FLAG_FEATURE_SIMD);
 
 #endif
 
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE, JIT_FLAG_MAKEFINALCODE);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_READYTORUN, JIT_FLAG_READYTORUN);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_ENTERLEAVE, JIT_FLAG_PROF_ENTERLEAVE);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_REJIT_NOPS, JIT_FLAG_PROF_REJIT_NOPS);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_NO_PINVOKE_INLINE, JIT_FLAG_PROF_NO_PINVOKE_INLINE);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SKIP_VERIFICATION, JIT_FLAG_SKIP_VERIFICATION);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PREJIT, JIT_FLAG_PREJIT);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_RELOC, JIT_FLAG_RELOC);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_IMPORT_ONLY, JIT_FLAG_IMPORT_ONLY);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB, JIT_FLAG_IL_STUB);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROCSPLIT, JIT_FLAG_PROCSPLIT);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBINSTR, JIT_FLAG_BBINSTR);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBOPT, JIT_FLAG_BBOPT);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FRAMED, JIT_FLAG_FRAMED);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_ALIGN_LOOPS, JIT_FLAG_ALIGN_LOOPS);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM, JIT_FLAG_PUBLISH_SECRET_PARAM);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_GCPOLL_INLINE, JIT_FLAG_GCPOLL_INLINE);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SAMPLING_JIT_BACKGROUND, JIT_FLAG_SAMPLING_JIT_BACKGROUND);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS, JIT_FLAG_USE_PINVOKE_HELPERS);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE, JIT_FLAG_REVERSE_PINVOKE);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DESKTOP_QUIRKS, JIT_FLAG_DESKTOP_QUIRKS);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_TIER0, JIT_FLAG_TIER0);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_TIER1, JIT_FLAG_TIER1);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_MAKEFINALCODE, JIT_FLAG_MAKEFINALCODE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_READYTORUN, JIT_FLAG_READYTORUN);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_ENTERLEAVE, JIT_FLAG_PROF_ENTERLEAVE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_REJIT_NOPS, JIT_FLAG_PROF_REJIT_NOPS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROF_NO_PINVOKE_INLINE, JIT_FLAG_PROF_NO_PINVOKE_INLINE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SKIP_VERIFICATION, JIT_FLAG_SKIP_VERIFICATION);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PREJIT, JIT_FLAG_PREJIT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_RELOC, JIT_FLAG_RELOC);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_IMPORT_ONLY, JIT_FLAG_IMPORT_ONLY);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_IL_STUB, JIT_FLAG_IL_STUB);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PROCSPLIT, JIT_FLAG_PROCSPLIT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBINSTR, JIT_FLAG_BBINSTR);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_BBOPT, JIT_FLAG_BBOPT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_FRAMED, JIT_FLAG_FRAMED);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_ALIGN_LOOPS, JIT_FLAG_ALIGN_LOOPS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM, JIT_FLAG_PUBLISH_SECRET_PARAM);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_GCPOLL_INLINE, JIT_FLAG_GCPOLL_INLINE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_SAMPLING_JIT_BACKGROUND, JIT_FLAG_SAMPLING_JIT_BACKGROUND);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS, JIT_FLAG_USE_PINVOKE_HELPERS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE, JIT_FLAG_REVERSE_PINVOKE);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_DESKTOP_QUIRKS, JIT_FLAG_DESKTOP_QUIRKS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_TIER0, JIT_FLAG_TIER0);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_TIER1, JIT_FLAG_TIER1);
 
 #if defined(_TARGET_ARM_)
 
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_RELATIVE_CODE_RELOCS, JIT_FLAG_RELATIVE_CODE_RELOCS);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_RELATIVE_CODE_RELOCS, JIT_FLAG_RELATIVE_CODE_RELOCS);
 
 #endif // _TARGET_ARM_
 
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_NO_INLINING, JIT_FLAG_NO_INLINING);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_NO_INLINING, JIT_FLAG_NO_INLINING);
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE3, JIT_FLAG_USE_SSE3);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSSE3, JIT_FLAG_USE_SSSE3);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE41, JIT_FLAG_USE_SSE41);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE42, JIT_FLAG_USE_SSE42);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AES, JIT_FLAG_USE_AES);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_BMI1, JIT_FLAG_USE_BMI1);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_BMI2, JIT_FLAG_USE_BMI2);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_FMA, JIT_FLAG_USE_FMA);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_LZCNT, JIT_FLAG_USE_LZCNT);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_PCLMULQDQ, JIT_FLAG_USE_PCLMULQDQ);
-		FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_POPCNT, JIT_FLAG_USE_POPCNT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE3, JIT_FLAG_USE_SSE3);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSSE3, JIT_FLAG_USE_SSSE3);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE41, JIT_FLAG_USE_SSE41);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_SSE42, JIT_FLAG_USE_SSE42);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_AES, JIT_FLAG_USE_AES);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_BMI1, JIT_FLAG_USE_BMI1);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_BMI2, JIT_FLAG_USE_BMI2);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_FMA, JIT_FLAG_USE_FMA);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_LZCNT, JIT_FLAG_USE_LZCNT);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_PCLMULQDQ, JIT_FLAG_USE_PCLMULQDQ);
+        FLAGS_EQUAL(CORJIT_FLAGS::CORJIT_FLAG_USE_POPCNT, JIT_FLAG_USE_POPCNT);
 #endif // _TARGET_X86_ || _TARGET_AMD64_
 
 #undef FLAGS_EQUAL
-	}
+    }
 
 private:
-	unsigned __int64 m_jitFlags;
+    unsigned __int64 m_jitFlags;
 };


### PR DESCRIPTION
JITFlags should be get by compiler while compile method, seems it can't be done directly, so the good idea to put to the 'todo' list